### PR TITLE
# is_empty_block / write_pointer fix

### DIFF
--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -179,11 +179,11 @@ impl Storage {
         self.write_pointer += write_size as u64;
         Ok(write_size)
     }
+    /// check if block is within storage file, without reading it from file (in memory)
     fn block_exists(&mut self, block_index: u32) -> bool {
-        // check if block exists withing storage file bounds
         block_index < self.end_block_count
     }
-    /// Check if block exists, without reading it from file (in memory)
+    /// Check if block is empty, without reading it from file (in memory)
     fn is_empty_block(&mut self, block_index: usize) -> bool {
         let block_index = block_index as u32;
         if self.block_exists(block_index) {


### PR DESCRIPTION
- end_block_count to Storage
- docs for Storage object's variables
- Storage.block_exists
- Storage.is_empty_block
- Implement is_empty_block in Storage.read_block (Close #5)
- use update Storage.write_pointer
-- in Storage.write_block
-- in Storage.delete_block